### PR TITLE
Helpers exposed directly to open internet without Load Balancing

### DIFF
--- a/eksctl/cluster-config.yaml
+++ b/eksctl/cluster-config.yaml
@@ -8,15 +8,15 @@ metadata:
 managedNodeGroups:
   - name: helper1
     labels: { releaseName: h1 }
-    instanceType: t3.medium
+    instanceType: c6id.8xlarge
     desiredCapacity: 1
   - name: helper2
     labels: { releaseName: h2 }
-    instanceType: t3.medium
+    instanceType: c6id.8xlarge
     desiredCapacity: 1
   - name: helper3
     labels: { releaseName: h3 }
-    instanceType: t3.medium
+    instanceType: c6id.8xlarge
     desiredCapacity: 1
 
 iam:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,7 +31,8 @@ spec:
             "--mk-public-key", "/etc/ipa/mk.pub",
             "--mk-private-key", "/etc/ipa/keys/mk.key"]
           ports:
-            - containerPort: {{ .Values.port }}
+            - hostPort: {{ .Values.port }}
+              containerPort: {{ .Values.port }}
           volumeMounts:
             - name: {{ .Release.Name }}-configs
               mountPath: /etc/ipa

--- a/templates/dockerconfigjson.yaml
+++ b/templates/dockerconfigjson.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-ghcr
   labels:
-    app: {{ .Release.Name }}-helper
+    app: {{ .Release.Name }}-helper-shard
 stringData:
   .dockerconfigjson: |
 {{ .Files.Get "config/ghcr_auth.json" | indent 4 }}

--- a/templates/helpers.yaml
+++ b/templates/helpers.yaml
@@ -1,38 +1,41 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-helper-deployment
+  name: {{ .Release.Name }}-helper-shard
   labels:
-    app: {{ .Release.Name }}-helper
+    app: {{ .Release.Name }}-helper-shard
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-helper
+      app: {{ .Release.Name }}-helper-shard
+  serviceName: {{ .Release.Name }}-helper-shard
+  replicas: 1 # number of shards
+  minReadySeconds: 10 # by default is 0
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-helper
+        app: {{ .Release.Name }}-helper-shard # has to match .spec.selector.matchLabels
     spec:
+      terminationGracePeriodSeconds: 10
       nodeSelector:
         releaseName: {{ .Release.Name }}
       imagePullSecrets:
         - name: {{ .Release.Name }}-ghcr
       containers:
-        - name: {{ .Release.Name }}-helper
+        - name: {{ .Release.Name }}-helper-shard
           image: {{ .Values.helperImage }}
           imagePullPolicy: Always
           command: ["ipa-helper"]
           args: ["--identity", "{{ trimPrefix "h" .Release.Name }}",
-            "--port", {{ .Values.port | quote }},
+            "--port", {{ .Values.externalPort | quote }},
             "--network", "/etc/ipa/network.toml", 
             "--tls-cert", "/etc/ipa/tls.pem",
             "--tls-key", "/etc/ipa/keys/tls.key",
             "--mk-public-key", "/etc/ipa/mk.pub",
             "--mk-private-key", "/etc/ipa/keys/mk.key"]
           ports:
-            - hostPort: {{ .Values.port }}
-              containerPort: {{ .Values.port }}
+            - hostPort: {{ .Values.externalPort }}
+              containerPort: {{ .Values.externalPort }}
           volumeMounts:
             - name: {{ .Release.Name }}-configs
               mountPath: /etc/ipa

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,17 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-lb
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
-    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+  name: {{ .Release.Name }}-ips
 spec:
-  type: LoadBalancer
+# https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+  type: ClusterIP
+  clusterIP: None
   selector:
     app: {{ .Release.Name }}-helper
   ports:
     - name: https
-      protocol: TCP
       port: {{ .Values.externalPort }}
-      targetPort: {{ .Values.port }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,7 +7,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    app: {{ .Release.Name }}-helper
+    app: {{ .Release.Name }}-helper-shard
   ports:
     - name: https
       port: {{ .Values.externalPort }}


### PR DESCRIPTION
The best approach seems to be:
A headless service: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
A statefulset instead of a deployment: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/

Also updated the EKSCTL template to use better hardware.